### PR TITLE
Add 'edit' link to help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ Make help text editable in the Wagtail admin
 
 - Python 3.7 - 3.10
 - Django 3.2 - 4.1
-- Wagtail 2.14 - 4.0
+- Wagtail 2.15 - 4.0
 
 ## Installation
 
 - Run `pip install wagtail-editable-help`
 - Add `"wagtail_editable_help"` and `"wagtail.contrib.modeladmin"` to INSTALLED_APPS
 - Run `./manage.py migrate`
+- Optional: add `"wagtail_editable_help.middleware.EditableHelpMiddleware"` to the MIDDLEWARE setting, somewhere below `"django.contrib.auth.middleware.AuthenticationMiddleware"`. Enabling this middleware will add an "Edit" link at the point the help text is shown, to allow superusers and other users with the appropriate permission to edit the help text.
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "Framework :: Wagtail :: 2",
         "Framework :: Wagtail :: 3",
     ],
-    install_requires=["Django>=3.0,<4.2", "wagtail>=2.14,<5"],
+    install_requires=["Django>=3.0,<4.2", "wagtail>=2.15,<5"],
     extras_require={
         "testing": ["dj-database-url==0.5.0", "freezegun==0.3.15"],
     },

--- a/wagtail_editable_help/middleware.py
+++ b/wagtail_editable_help/middleware.py
@@ -1,0 +1,26 @@
+from asgiref.local import Local
+
+
+_local_data = Local()
+
+
+class EditableHelpMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if hasattr(request, 'user'):
+            _local_data.user = request.user
+
+        response = self.get_response(request)
+
+        try:
+            del _local_data.user
+        except AttributeError:
+            pass
+
+        return response
+
+
+def get_active_user():
+    return getattr(_local_data, 'user', None)

--- a/wagtail_editable_help/models.py
+++ b/wagtail_editable_help/models.py
@@ -49,7 +49,10 @@ class HelpText:
             finder = AdminURLFinder(user)
             edit_url = finder.get_edit_url(str)
         if user and edit_url:
-            return format_html('{} (<a href="{}">{}</a>)', str.text, edit_url, _("Edit"))
+            if str.text:
+                return format_html('{} <a href="{}" class="edit-help-text">{}</a>', str.text, edit_url, _("Edit"))
+            else:
+                return format_html('<a href="{}" class="add-help-text">{}</a>', edit_url, _("Add help text"))
         else:
             return str.text
 

--- a/wagtail_editable_help/models.py
+++ b/wagtail_editable_help/models.py
@@ -1,5 +1,10 @@
 from django.db import models
 from django.utils.deconstruct import deconstructible
+from django.utils.html import format_html
+from django.utils.translation import gettext as _
+from wagtail.admin.admin_url_finder import AdminURLFinder
+
+from .middleware import get_active_user
 
 
 class HelpTextString(models.Model):
@@ -39,7 +44,14 @@ class HelpText:
             model_label=self.model_label, identifier=self.identifier,
             defaults={'text': self.default}
         )
-        return str.text
+        user = get_active_user()
+        if user:
+            finder = AdminURLFinder(user)
+            edit_url = finder.get_edit_url(str)
+        if user and edit_url:
+            return format_html('{} (<a href="{}">{}</a>)', str.text, edit_url, _("Edit"))
+        else:
+            return str.text
 
     def __hash__(self):
         return hash((self.model_label, self.identifier))

--- a/wagtail_editable_help/static/wagtail_editable_help/wagtail_editable_help.css
+++ b/wagtail_editable_help/static/wagtail_editable_help/wagtail_editable_help.css
@@ -1,0 +1,10 @@
+a.edit-help-text {
+    font-size: 0.9em;
+    padding-left: 0.5em;
+    text-decoration: underline;
+}
+
+a.add-help-text {
+    font-size: 0.9em;
+    text-decoration: underline;
+}

--- a/wagtail_editable_help/test/migrations/0001_initial.py
+++ b/wagtail_editable_help/test/migrations/0001_initial.py
@@ -19,6 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.page')),
                 ('tagline', models.CharField(help_text=wagtail_editable_help.models.HelpText('Home page', 'tagline', default='Write something snappy here'), max_length=255)),
+                ('body', models.TextField(blank=True, help_text=wagtail_editable_help.models.HelpText('Home page', 'body'))),
             ],
             options={
                 'abstract': False,

--- a/wagtail_editable_help/test/models.py
+++ b/wagtail_editable_help/test/models.py
@@ -14,7 +14,9 @@ from wagtail_editable_help.models import HelpText
 
 class HomePage(Page):
     tagline = models.CharField(max_length=255, help_text=HelpText("Home page", "tagline", default="Write something snappy here"))
+    body = models.TextField(blank=True, help_text=HelpText("Home page", "body"))
 
     content_panels = Page.content_panels + [
         FieldPanel("tagline"),
+        FieldPanel("body"),
     ]

--- a/wagtail_editable_help/test/settings.py
+++ b/wagtail_editable_help/test/settings.py
@@ -68,6 +68,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+    "wagtail_editable_help.middleware.EditableHelpMiddleware",
 ]
 
 ROOT_URLCONF = "wagtail_editable_help.test.urls"

--- a/wagtail_editable_help/test/tests/test_admin.py
+++ b/wagtail_editable_help/test/tests/test_admin.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Group, User
 from django.test import TestCase
 
 try:
@@ -12,6 +12,8 @@ from wagtail_editable_help.models import HelpTextString
 class TestAdmin(TestCase):
     def setUp(self):
         self.superuser = User.objects.create_superuser("admin", "admin@example.com", "password")
+        self.normal_user = User.objects.create_user("ed", "ed@example.com", "password")
+        self.normal_user.groups.add(Group.objects.get(name="Editors"))
         self.root_page = Page.objects.get(depth=2)
 
     def test_get_default_text(self):
@@ -30,7 +32,7 @@ class TestAdmin(TestCase):
         self.assertEqual(HelpTextString.objects.count(), 1)
 
     def test_get_alternative_text(self):
-        HelpTextString.objects.create(
+        help_text = HelpTextString.objects.create(
             model_label="Home page", identifier="tagline", text="Write something clickbaity here"
         )
         self.client.login(username="admin", password="password")
@@ -42,6 +44,28 @@ class TestAdmin(TestCase):
         # Help text should pick up the custom HelpTextString record
         self.assertNotContains(response, "Write something snappy here")
         self.assertContains(response, "Write something clickbaity here")
+
+        # superuser should get the Edit link
+        self.assertContains(response, '(<a href="/admin/wagtail_editable_help/helptextstring/edit/%d/">Edit</a>)' % help_text.id)
+
+        self.assertEqual(HelpTextString.objects.count(), 1)
+
+    def test_get_alternative_text_as_normal_user(self):
+        help_text = HelpTextString.objects.create(
+            model_label="Home page", identifier="tagline", text="Write something clickbaity here"
+        )
+        self.client.login(username="ed", password="password")
+        response = self.client.get(
+            "/admin/pages/add/wagtail_editable_help_test/homepage/%d/" % self.root_page.id
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Help text should pick up the custom HelpTextString record
+        self.assertNotContains(response, "Write something snappy here")
+        self.assertContains(response, "Write something clickbaity here")
+
+        # normal user without edit permission on HelpTextString should not get the Edit link
+        self.assertNotContains(response, '(<a href="/admin/wagtail_editable_help/helptextstring/edit/%d/">Edit</a>)' % help_text.id)
 
         self.assertEqual(HelpTextString.objects.count(), 1)
 

--- a/wagtail_editable_help/test/tests/test_admin.py
+++ b/wagtail_editable_help/test/tests/test_admin.py
@@ -28,11 +28,11 @@ class TestAdmin(TestCase):
         # with no pre-existing HelpTextString record, the default text should be shown
         self.assertContains(response, "Write something snappy here")
 
-        # a new HelpTextString record now exists
-        self.assertEqual(HelpTextString.objects.count(), 1)
+        # a new HelpTextString record now exists for each field
+        self.assertEqual(HelpTextString.objects.count(), 2)
 
     def test_get_alternative_text(self):
-        help_text = HelpTextString.objects.create(
+        tagline_help_text = HelpTextString.objects.create(
             model_label="Home page", identifier="tagline", text="Write something clickbaity here"
         )
         self.client.login(username="admin", password="password")
@@ -45,13 +45,17 @@ class TestAdmin(TestCase):
         self.assertNotContains(response, "Write something snappy here")
         self.assertContains(response, "Write something clickbaity here")
 
-        # superuser should get the Edit link
-        self.assertContains(response, '(<a href="/admin/wagtail_editable_help/helptextstring/edit/%d/">Edit</a>)' % help_text.id)
+        body_help_text = HelpTextString.objects.get(model_label="Home page", identifier="body")
 
-        self.assertEqual(HelpTextString.objects.count(), 1)
+        # superuser should get the Edit link
+        self.assertContains(response, '<a href="/admin/wagtail_editable_help/helptextstring/edit/%d/" class="edit-help-text">Edit</a>' % tagline_help_text.id)
+        # and an Add link
+        self.assertContains(response, '<a href="/admin/wagtail_editable_help/helptextstring/edit/%d/" class="add-help-text">Add help text</a>' % body_help_text.id)
+
+        self.assertEqual(HelpTextString.objects.count(), 2)
 
     def test_get_alternative_text_as_normal_user(self):
-        help_text = HelpTextString.objects.create(
+        tagline_help_text = HelpTextString.objects.create(
             model_label="Home page", identifier="tagline", text="Write something clickbaity here"
         )
         self.client.login(username="ed", password="password")
@@ -64,10 +68,13 @@ class TestAdmin(TestCase):
         self.assertNotContains(response, "Write something snappy here")
         self.assertContains(response, "Write something clickbaity here")
 
-        # normal user without edit permission on HelpTextString should not get the Edit link
-        self.assertNotContains(response, '(<a href="/admin/wagtail_editable_help/helptextstring/edit/%d/">Edit</a>)' % help_text.id)
+        body_help_text = HelpTextString.objects.get(model_label="Home page", identifier="body")
 
-        self.assertEqual(HelpTextString.objects.count(), 1)
+        # normal user without edit permission on HelpTextString should not get the Edit/Add link
+        self.assertNotContains(response, '<a href="/admin/wagtail_editable_help/helptextstring/edit/%d/" class="edit-help-text">Edit</a>' % tagline_help_text.id)
+        self.assertNotContains(response, '<a href="/admin/wagtail_editable_help/helptextstring/edit/%d/" class="add-help-text">Add help text</a>' % body_help_text.id)
+
+        self.assertEqual(HelpTextString.objects.count(), 2)
 
     def test_help_text_strings_index(self):
         self.client.login(username="admin", password="password")

--- a/wagtail_editable_help/wagtail_hooks.py
+++ b/wagtail_editable_help/wagtail_hooks.py
@@ -1,3 +1,11 @@
+from django.utils.html import format_html
+from django.templatetags.static import static
+
+try:
+    from wagtail import hooks
+except ImportError:
+    from wagtail.core import hooks
+
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, modeladmin_register)
 from .models import HelpTextString, populate_help_text_strings
@@ -28,3 +36,8 @@ class HelpTextAdmin(ModelAdmin):
 
 
 modeladmin_register(HelpTextAdmin)
+
+
+@hooks.register("insert_global_admin_css")
+def editable_help_css():
+    return format_html('<link rel="stylesheet" href="{}">', static('wagtail_editable_help/wagtail_editable_help.css'))


### PR DESCRIPTION
Users with edit permission over help text strings are now shown an "Edit" link alongside the displayed help text. This relies on a custom middleware - details for installing this are added to the readme.

![Screenshot 2022-09-08 at 11 50 00](https://user-images.githubusercontent.com/85097/189104036-26ddb4c6-1854-4354-b378-61df9016a7cd.png)

(The minimum supported Wagtail version for this package is now 2.15, as we rely on AdminURLFinder to locate the edit URL and perform the permission check.)