### PR TITLE
Ensure that the help string listing is fully populated on initial visit

### DIFF
--- a/wagtail_editable_help/models.py
+++ b/wagtail_editable_help/models.py
@@ -16,11 +16,15 @@ class HelpTextString(models.Model):
         ordering = ("identifier",)
 
 
+_help_text_objects = set()
+
+
 @deconstructible
 class HelpText:
     def __init__(self, identifier, default=""):
         self.identifier = identifier
         self.default = default
+        _help_text_objects.add(self)
 
     def __str__(self):
         str, created = HelpTextString.objects.get_or_create(
@@ -28,5 +32,17 @@ class HelpText:
         )
         return str.text
 
+    def __hash__(self):
+        return hash(self.identifier)
+
     def __eq__(self, other):
         return isinstance(other, HelpText) and other.identifier == self.identifier
+
+
+def populate_help_text_strings():
+    """
+    Ensure that a HelpTextString record exists in the database for all HelpText
+    definitions that have been encountered during module loading
+    """
+    for item in _help_text_objects:
+        str(item)

--- a/wagtail_editable_help/test/tests/test_admin.py
+++ b/wagtail_editable_help/test/tests/test_admin.py
@@ -44,3 +44,13 @@ class TestAdmin(TestCase):
         self.assertContains(response, "Write something clickbaity here")
 
         self.assertEqual(HelpTextString.objects.count(), 1)
+
+    def test_help_text_strings_index(self):
+        self.client.login(username="admin", password="password")
+        response = self.client.get("/admin/wagtail_editable_help/helptextstring/")
+        self.assertEqual(response.status_code, 200)
+
+        # The listing should contain all defined HelpTextString records,
+        # even if we never triggered their creation by visiting a view that rendered them
+        self.assertContains(response, "Home page tagline")
+        self.assertContains(response, "Write something snappy here")

--- a/wagtail_editable_help/wagtail_hooks.py
+++ b/wagtail_editable_help/wagtail_hooks.py
@@ -1,6 +1,9 @@
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, modeladmin_register)
-from .models import HelpTextString
+from .models import HelpTextString, populate_help_text_strings
+
+
+_has_populated_records = False
 
 
 class HelpTextAdmin(ModelAdmin):
@@ -9,6 +12,17 @@ class HelpTextAdmin(ModelAdmin):
     menu_icon = "help"
     add_to_settings_menu = True
     list_display = ('identifier', 'text')
+
+    def get_queryset(self, request):
+        # On first call to any ModelAdmin view that retrieves the queryset,
+        # ensure that all HelpText definitions in the code have been turned into
+        # HelpTextString records in the database
+        global _has_populated_records
+        if not _has_populated_records:
+            populate_help_text_strings()
+            _has_populated_records = True
+
+        return super().get_queryset(request)
 
 
 modeladmin_register(HelpTextAdmin)


### PR DESCRIPTION
On first visit to the help string index view, run str() over all HelpText objects that have been defined, to ensure that they have corresponding records in the database