### PR TITLE
Run CircleCI workflows with Python 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   flake8:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.12
     steps:
       - checkout
       - run: pip install flake8
@@ -11,7 +11,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.12
     steps:
       - checkout
 
@@ -32,7 +32,7 @@ jobs:
 
   nightly-wagtail-test:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.12
     steps:
       - checkout
       - run: git clone git@github.com:wagtail/wagtail.git


### PR DESCRIPTION
Wagtail main has dropped support for Python 3.8